### PR TITLE
refs #9 コマンドラインオプションで name オプションが指定された場合の処理を追加

### DIFF
--- a/src/main/java/com/github/finder/Finder.java
+++ b/src/main/java/com/github/finder/Finder.java
@@ -33,4 +33,16 @@ public class Finder {
             }
         }
     }
+
+    private boolean isTarget(File file){
+        boolean flag = true;
+        if(args.getName() != null){
+            flag &= checkTargetName(file, args.getName());
+        }
+        return flag;
+    }
+    private boolean checkTargetName(File file, String pattern){
+        String name = file.getName();
+        return name.indexOf(pattern) >= 0;
+    }
 }


### PR DESCRIPTION
nameオプションが指定された場合、ファイル名が一致するかを確認し、ファイル名が一致した場合のみ、isTarget メソッドが true
を返すようにしました。
